### PR TITLE
Added support for woff2 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Easily download Google Webfonts as a zip file
 
 ## API
 
-* `/<type>/css` Creates a zip archive of font family provided, where `type` can be one of `tff`, `woff` or `eotwoff` (default).
+* `/<type>/css` Creates a zip archive of font family provided, where `type` can be one of `tff`, `woff`,`woff2` or `eotwoff` (default).
 
 ## Remote Usage (Pre-hosted)
 

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ var baseURL = "http://fonts.googleapis.com";
 var types = {
 	tff: "Node.js",
 	woff: "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0",
+	woff2: "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.120 Safari/537.36",
 	eotwoff: "Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))"
 };
 
@@ -89,7 +90,7 @@ function finalizeArchive(archive, cb) {
 app.use(function(req, res) {
 	if(/^\/ping/.test(req.url))
 		return res.send("Pong");
-	if(!/^(\/[a-z]+)?(\/css\?family=([^\:]+)\:.+)/.test(req.url))
+	if(!/^(\/[a-z2]+)?(\/css\?family=([^\:]+)\:.+)/.test(req.url))
 		return res.status(400).send("Invalid request");
 	var type = RegExp.$1.substr(1);
 	var query = RegExp.$2;


### PR DESCRIPTION
Woff2 is more lightweight format. It's currently sent to Webkit-based browsers by Google. It actually might be worth including in the archive (I didn't add that).
